### PR TITLE
Fix: added graceful failing for the case when the ratelim datastore is unavailable

### DIFF
--- a/src/app/exceptions/data_store_conn_error.py
+++ b/src/app/exceptions/data_store_conn_error.py
@@ -1,0 +1,12 @@
+""" Module that holds custom exceptions in the backend application"""
+
+
+class DataStoreConnectionError(ConnectionError):
+    """ Exception to be raised whenever a connection to the data store fails
+       it does not depend on the datastore, so the main application (logic layer)
+       will catch this, instead of a data store specific exception
+       (e.g., redis.exceptions.ConnectionError)
+    """
+    def __init__(self, message: str = "Failed to connect to the rate limiting data store"):
+        self.message = message
+        super().__init__(message)

--- a/src/app/main_app.py
+++ b/src/app/main_app.py
@@ -2,7 +2,7 @@
 
 import uvicorn
 from fastapi import FastAPI
-from src.app.routes.qr import get_qr_router as qr_router
+from src.app.routes.qr import get_qr_router as qr_router, qr_route_custom_exception_handler
 from src.app.ratelim.service.rate_limit_config_builder import build_rate_limit_config
 
 
@@ -14,6 +14,7 @@ def create_app(test_config: dict = None) -> FastAPI:
     """
     rate_limit_config = build_rate_limit_config(test_config)
     app = FastAPI()
+    qr_route_custom_exception_handler(app)
     app.include_router(qr_router(rate_limit_config))
     return app
 

--- a/src/app/ratelim/service/redis_manager.py
+++ b/src/app/ratelim/service/redis_manager.py
@@ -4,7 +4,9 @@ import os
 # note: no redis.asyncio here. we need the
 # rate limiter check sync with the app
 from redis import Redis
+from redis.exceptions import ConnectionError
 from src.app.ratelim.service.rate_limiter_intf import RateLimiterInterface
+from src.app.exceptions.data_store_conn_error import DataStoreConnectionError
 
 class RedisManager(RateLimiterInterface):
     """ Utility class to interface with Redis as the underlying data store
@@ -22,7 +24,10 @@ class RedisManager(RateLimiterInterface):
     def set(self, key: str, value: dict):
         """ Method to set the pair (key, value) in the Redis instance
         """
-        self.redis.hset(key, mapping=value)
+        try:
+            self.redis.hset(key, mapping=value)
+        except ConnectionError as exc:
+            raise DataStoreConnectionError from exc
 
     def get(self, key: object):
         """Method to check whether the request will be rate limited,
@@ -32,7 +37,10 @@ class RedisManager(RateLimiterInterface):
             key (object): id of the object to be identified, usually an IP associated with 
                           the requester.
         """
-        return self.redis.hgetall(key)
+        try:
+            return self.redis.hgetall(key)
+        except ConnectionError as exc:
+            raise DataStoreConnectionError from exc
 
     @staticmethod
     def create():
@@ -42,18 +50,29 @@ class RedisManager(RateLimiterInterface):
         Returns:
             RedisManager: Abstraction to manage the Redis interface implementation
         """
-        redis_host = os.getenv("REDIS_HOST")
-        redis_port = os.getenv("REDIS_PORT")
-        username = os.getenv("REDIS_USERNAME")
-        password = os.getenv("REDIS_PASSWORD")
-        return RedisManager(redis_host, redis_port, username, password)
+        try:
+            redis_host = os.getenv("REDIS_HOST")
+            redis_port = os.getenv("REDIS_PORT")
+            username = os.getenv("REDIS_USERNAME")
+            password = os.getenv("REDIS_PASSWORD")
+            return RedisManager(redis_host, redis_port, username, password)
+        except ConnectionError as exc:
+            raise DataStoreConnectionError from exc
 
 class MockRedis(RateLimiterInterface):
+    """Mock class to mimic a key value store but in memory
+       this is only to be used within unit tests!!!
+
+    Args:
+        RateLimiterInterface (object): the interface to describe a rate limiting interface
+                                       any class that functions like the rate limiting class
+                                       needs to implement these methods.
+    """
     def __init__(self):
         self.store = {}
 
     def get(self, key):
         return self.store.get(key)
 
-    def set(self, key, value, ex=None):
+    def set(self, key, value):
         self.store[key] = value

--- a/src/app/routes/qr.py
+++ b/src/app/routes/qr.py
@@ -4,13 +4,36 @@ import uuid #for now, generates the temp file on disk with UUID.
 import os
 import tempfile
 from pathlib import Path
-from fastapi import APIRouter, Depends
+from fastapi import FastAPI, APIRouter, Depends
+from fastapi.requests import Request
 from fastapi.responses import JSONResponse, Response
-from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_503_SERVICE_UNAVAILABLE
 from src.app.models.qr_code_image import QRCodeImage
 from src.app.services.qr_code_service import create_qr_code
 from src.app.ratelim.service.rate_limiter_service import RateLimiterService
 from src.app.ratelim.models.rate_limit_config import RateLimitConfig
+from src.app.exceptions.data_store_conn_error import DataStoreConnectionError
+
+# fix: adding a generic exception handler to deal with the case
+# where a dependency raises an exception. This happens between the
+# endpoint call and the FastAPI instantiation, and FastAPI only 
+# allows custom exception handlers to be attached to the FastAPI instance
+# see https://fastapi.tiangolo.com/tutorial/handling-errors/?h=hand#install-custom-exception-handlers 
+# for more info
+
+def qr_route_custom_exception_handler(app: FastAPI):
+    """Route handler for the FastAPI object
+
+    Args:
+        app (FastAPI): Main API object, denoting our
+    """
+    @app.exception_handler(DataStoreConnectionError)
+    async def datastore_connection_error_handler(request: Request, exception: DataStoreConnectionError):
+        return JSONResponse(
+            status_code=HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+            "message": "An error has occurred! Please try again after a couple of seconds, and reach out the administrator if the problem persists"
+        })
 
 
 def get_qr_router(rate_limiter_config : RateLimitConfig) -> APIRouter:
@@ -18,7 +41,6 @@ def get_qr_router(rate_limiter_config : RateLimitConfig) -> APIRouter:
     FILE_PATH = os.path.join(Path(__file__).parent.parent, "static")
     #rate limiting is set by route, but created elsewhere:
     rate_limiter = RateLimiterService.get_instance(rate_limiter_config.data_store)
-
     @router.post("/qr", dependencies=[Depends(rate_limiter.check_rate_limiting)])
     async def generate_qr_code(payload: QRCodeImage):
         """ Generate a QR Code based on the request data


### PR DESCRIPTION
# Tl;dr
Added a means for the api to fail gracefully if the rate limiter data store is not available, instead of just pushing back a generic "Internal Server Error" message

# Context
This change was raised due to the fact that if the redis instance is not active, then the rate limiting algorithm fails and the whole application crashes. I have added a more meaningful message for the user to avoid having that generic HTTP 500 status error message. As we have discussed, this scneario is a unrecoverable one, so if this happens, the user can wait a bit, and if it persists, then contact the IT department because there's likely something really wrong with its Redis instance.

Note that I have maintained the error handling logic decoupled from the underlying data store by creating a new exception which is treated by the FastAPI app, wrapping the exception that is raised specifically by the data store (e.g., Redis will raise redis.exceptions.ConnectionError in these cases).

# Test Plan
Start the server without a Redis instance available in the endpoint set up in environment variables REDIS_HOST and REDIS_PORT. 
The service should return something like the below message: 

<img width="713" height="276" alt="image" src="https://github.com/user-attachments/assets/c78217f1-f68b-4565-aadb-61551e477780" />


# Checklist 
- [X] Pull request title is succinct with [tiny] if it’s extra small
- [X] Describes the problem
- [X] Describes the solution (screenshots included if UI changes)
- [X] Has a test plan
- [ ] Contains links to any context (Slack, Figma, JIRA ticket, etc.)
- [X] Code is self reviewed for readability, approach, and edge cases
- [X] Lines changed that may require additional explanation are annotated with an explanation
- [ ] Change is ideally < 500 lines if possible. < 150 is ideal.