### PR TITLE
Fix/api param handling

### DIFF
--- a/frontend/qr-code-app/src/app/components/Dropdown.tsx
+++ b/frontend/qr-code-app/src/app/components/Dropdown.tsx
@@ -5,9 +5,9 @@ import { FaCaretDown } from "react-icons/fa";
 export default function Dropdown() {
     
     const [ isOpen, setIsOpen ] = useState(false);
-    const [ selectedVersion, setSelectedVersion ] = useState('Select Version');
+    const [ selectedVersion, setSelectedVersion ] = useState('Auto');
 
-    const versionList = ['1','2','3','4','5','6','7','8'];
+    const versionList = ['Auto','1','2','3','4','5','6','7','8'];
 
     const toggleDown = () => {
         setIsOpen(!isOpen);

--- a/frontend/qr-code-app/src/app/components/ECLDropdown.tsx
+++ b/frontend/qr-code-app/src/app/components/ECLDropdown.tsx
@@ -5,9 +5,9 @@ import { FaCaretDown } from "react-icons/fa";
 export default function Dropdown() {
     
     const [ isOpen, setIsOpen ] = useState(false);
-    const [ selectedECL, setSelectedVersion ] = useState('Select Error Correction Level');
+    const [ selectedECL, setSelectedVersion ] = useState('Auto');
 
-    const eclList = ['L','H','Q','M'];
+    const eclList = ['Auto','L','H','Q','M'];
 
     const toggleDown = () => {
         setIsOpen(!isOpen);

--- a/frontend/qr-code-app/src/app/components/Page.tsx
+++ b/frontend/qr-code-app/src/app/components/Page.tsx
@@ -5,22 +5,23 @@ import Dropdown from './Dropdown';
 import ECLDropdown from './ECLDropdown';
 import QRCode from './QRCode';
 import { useState } from 'react';
-
+import { QRCodeStruct } from './interfaces/QRCode';
 
 export default function Page(){
 
-
-    const[qrCodeInput, setQRCodeInput] = useState<{
-        data: string,
-        version: string,
-        errorCorrectionLevel: string
-    } | null>(null);
+    const[qrCodeInput, setQRCodeInput] = useState<QRCodeStruct | null>(null);
 
     function createQRCode(formData: FormData) {
-        const rawFormData = {
+
+        const rawFormData : QRCodeStruct = {
             data : formData.get('qrCodeText') as string,
-            version: document.getElementById("versionDropdown")?.textContent as string || null,
-            errorCorrectionLevel : document.getElementById("eclDropdown")?.textContent as string || null
+            version: document.getElementById("versionDropdown")?.textContent as string,
+            errorCorrectionLevel : document.getElementById("eclDropdown")?.textContent as string
+        }
+        // validatePayload(rawFormData);
+        if (!rawFormData?.data) {
+            alert("Please provide a valid QR code text");
+            return;
         }
         setQRCodeInput(rawFormData);
     }

--- a/frontend/qr-code-app/src/app/components/QRCode.tsx
+++ b/frontend/qr-code-app/src/app/components/QRCode.tsx
@@ -1,15 +1,7 @@
 "use client";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-
-
-export interface QRCodeStruct {
-    qrCodeData? : {
-        data: string;
-        version: string;
-        errorCorrectionLevel: string;
-    };
-}
+import { QRCodeStruct } from './interfaces/QRCode';
 
 export default function QRCode( { qrCodeData } : QRCodeStruct) {
 
@@ -18,7 +10,7 @@ export default function QRCode( { qrCodeData } : QRCodeStruct) {
 
     async function fetchQRCode( data : {
             data : string,
-            version : string,
+            version : number,
             errorCorrectionLevel: string
     }) {
         try {

--- a/frontend/qr-code-app/src/app/components/interfaces/QRCode.tsx
+++ b/frontend/qr-code-app/src/app/components/interfaces/QRCode.tsx
@@ -1,0 +1,5 @@
+export interface QRCodeStruct {
+    data: string;
+    version: string;
+    errorCorrectionLevel: string;
+}

--- a/src/app/models/qr_code_image.py
+++ b/src/app/models/qr_code_image.py
@@ -1,12 +1,53 @@
 """FastAPI compatible model using Pydantic"""
-
-from pydantic import BaseModel
+from typing import Union
+from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic.alias_generators import to_camel
 
 class QRCodeImage(BaseModel):
     """Pydantic model for QRCode image class
-       to be used in FastAPI
+    to be used in FastAPI
     """
+    model_config = ConfigDict(alias_generator=to_camel)
     data: str
-    version: int | None = None
-    error_correction_level: str | None = None
-    module_size: int | None = None
+    # version: Union[int, str] = None
+    version: Union[int, None] = None
+    error_correction_level: Union[str, None] = None
+    module_size: Union[int, None] = None
+
+    @field_validator('version', mode='before')
+    @classmethod
+    def validate_version(cls, version: int):
+        """Validates the version to be a valid int between 1 and 40.
+
+        Args:
+            val (int): value provided as the QR Code version
+
+        Returns:
+            int | None: a valid integer if 1 <= val <= 40, and None if val == 'Auto'
+        """
+        if version == 'Auto':
+            return None
+        int_val = int(version)
+        if 1 <= int_val <= 40:
+            return int_val
+        return None
+
+    @field_validator('error_correction_level', mode='before')
+    @classmethod
+    def validate_ecl(cls, ecl: str) -> str | None:
+        """validates ECL values, and allow the special case 'Auto' to be calculated by the system
+
+        Args:
+            val (str): QR Code error correction level
+
+        Raises:
+            ValueError: raised if the provided ECL is not one of the following: 'H', 'L', 'Q' or 'M'
+
+        Returns:
+            str | None: str if a valid ECL, None if it's the 'Auto' scenario
+        """
+        if ecl == 'Auto':
+            return None
+        if ecl not in ['L','H','Q','M']:
+            raise ValueError(f'Invalid error correction value type {ecl}')
+        return ecl

--- a/test/app/test_api_qr_code.py
+++ b/test/app/test_api_qr_code.py
@@ -56,6 +56,20 @@ class TestBasicAPIOperations(unittest.TestCase):
         qr_response = self.client.post("/qr", json=body, headers=self.test_headers )
         self.assertEqual(qr_response.status_code, HTTP_422_UNPROCESSABLE_ENTITY)
 
+    def test_api_call_with_auto_params(self):
+        """Method to test functionality of processing "Auto" parameters
+           which triggers the feature to calculate the minimum version and ECL that
+           fits the QR code text.
+        """
+        super().setUp()
+        body = {
+	        "data": "test code",
+            "version": "Auto",
+            "errorCorrectionLevel": "Auto"
+        }
+        response = self.client.post('/qr', json=body, headers=self.test_headers)
+        self.assertEqual(response.status_code, HTTP_200_OK)
+
 class TestAPIRateLimiter(unittest.TestCase):
     """Class to test rate limiting functionalities
 


### PR DESCRIPTION
# Tl;dr
This change fixes the current Issue
- Current version does not support "Auto" parameter (so the system calculates the minimal version and ECL to where the data fits)

# Context
This change enables the usage of "Auto" parameters for both Version and Error Correction Level (ECL), both simultaneously or one at each time. The idea is to allow the user to not select a version or an ECL code, and have the system to automatically calculate the smallest combination of Version and Error Correction Level that fits the QR code data

# Test Plan
- Create a QR code with both Level and ECL set
- Create a QR Code with only Level set as a value, and ECL as "Auto"
- Create a QR Code with both level and ECL as "Auto"

# Links
N/A

# Checklist 
- [X] Pull request title is succinct with [tiny] if it’s extra small
- [X] Describes the problem
- [X] Describes the solution (screenshots included if UI changes)
- [X] Has a test plan
- [ ] Contains links to any context (Slack, Figma, JIRA ticket, etc.)
- [X] Code is self reviewed for readability, approach, and edge cases
- [X] Lines changed that may require additional explanation are annotated with an explanation
- [X] Change is ideally < 500 lines if possible. < 150 is ideal.